### PR TITLE
build(core): scaffolding for the jaseci plugin and pre-commit setup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = fixtures, __jac_gen__
+plugins = flake8_import_order, flake8_docstrings, flake8_comprehensions, flake8_bugbear, flake8_annotations, pep8_naming, flake8_simplify
+max-line-length = 120
+ignore = E203, W503, ANN101, ANN102

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,0 +1,25 @@
+name: Linting and Pre-commit checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.12
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run pre-commit hooks
+      run: pre-commit run --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Django #
+*.log
+*.pot
+*.pyc
+__pycache__
+db.sqlite3
+media
+migrations
+venv
+__jac_gen__/
+*.jir
+
+# Distribution / packaging
+.Python
+play/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Others #
+.env
+.coverage
+.session
+.DS_Store
+build
+.vscode
+*Zone.Identifier
+.DS_Store
+parser.out
+codegen_output*
+
+*.rdb
+node_modules
+out.dot
+out.txt
+
+# Mypy files #
+.mypy_cache*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [pep8-naming, flake8_import_order, flake8_docstrings, flake8_comprehensions, flake8_bugbear, flake8_annotations, flake8_simplify]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-redis, motor-types]
+        exclude: 'venv|__jac_gen__|tests|setup.py'
+        args:
+          - --follow-imports=silent
+          - --ignore-missing-imports

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+## Jaseci plugin for Jaclang
+
+### Dependencies
+
+```bash
+pip install jaclang black pre-commit pytest flake8 flake8_import_order flake8_docstrings flake8_comprehensions flake8_bugbear flake8_annotations pep8_naming flake8_simplify mypy
+pre-commit install
+```

--- a/jaclang_jaseci/__init__.py
+++ b/jaclang_jaseci/__init__.py
@@ -1,0 +1,12 @@
+"""JacLang FastAPI."""
+
+from dotenv import find_dotenv, load_dotenv
+
+from .core import FastAPI
+
+
+load_dotenv(find_dotenv(), override=True)
+
+start = FastAPI.start
+
+__all__ = ["FastAPI", "start"]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = venv|__jac_gen__|tests|setup.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+"""Jaclang setup file."""
+
+from __future__ import annotations
+
+from setuptools import find_packages, setup
+
+
+VERSION = "0.0.1"
+
+setup(
+    name="jaclang-jaseci",
+    version=VERSION,
+    packages=find_packages(include=["jaclang_jaseci", "jaclang_jaseci.*"]),
+    install_requires=[
+        "jaclang",
+        "fastapi==0.109.0",
+        "pydantic==2.6.0",
+        "pymongo==4.6.1",
+        "motor==3.3.2",
+        "motor-types==1.0.0b4",
+        "python-dotenv==1.0.1",
+        "uvicorn==0.27.0.post1",
+        "pyjwt[crypto]==2.8.0",
+        "passlib[bcrypt]==1.7.4",
+        "email-validator==2.1.0.post1",
+        "orjson==3.9.13",
+        "redis==5.0.1",
+        "types-redis==4.6.0.20240218",
+        "python-multipart==0.0.9",
+        "httpx==0.27.0",
+    ],
+    package_data={},
+    entry_points={
+        "jac": [],
+    },
+    author="Jason Mars, Yiping Kang, Alexie Madolid",
+    author_email="jason@jaseci.org",
+    url="https://github.com/Jaseci-Labs/jaclang-jaseci",
+)


### PR DESCRIPTION
Initialize the jaseci plugin.

* Add flake8 config for linting
* Add pre-commit configuration
* github action for linting
* setup.py for the plugin.
    * this does already include the packages we will need for the subsequent PRs.